### PR TITLE
really fix "Component is not a constructor" error

### DIFF
--- a/src/FileUpload.vue
+++ b/src/FileUpload.vue
@@ -332,7 +332,7 @@ export default {
 
       var Component = this.$options.components.InputFile;
       if (Component._Ctor) {
-        Component = Component._Ctor
+        Component = Component._Ctor[0]
       }
       var inputFile = new Component({
         parent: this,


### PR DESCRIPTION
In my Chrome browser, the `Component._Ctor` is not a constructor, but `Component._Ctor[0]`

The error go away after I changed to that.