### PR TITLE
fix cancel drop with ESC

### DIFF
--- a/src/FileUpload.vue
+++ b/src/FileUpload.vue
@@ -1199,7 +1199,7 @@ export default {
 
     onDragleave(e) {
       e.preventDefault()
-      if (e.target.nodeName === 'HTML' || (e.screenX === 0 && e.screenY === 0 && e.screenY === 0 && !e.fromElement && e.offsetX < 0)) {
+      if (e.target.nodeName === 'HTML' || (e.screenX === 0 && e.screenY === 0 && !e.fromElement && e.offsetX <= 0)) {
         this.dropActive = false
       }
     },


### PR DESCRIPTION
$refs.upload.dropActive is still 'true' when drop of file is canceled by pressing ESC key.  The problem is in 'onDragLeave' callback.
```
 onDragleave(e) {
      e.preventDefault()
      if (e.target.nodeName === 'HTML' || (e.screenX === 0 && e.screenY === 0 && e.screenY === 0 && !e.fromElement && e.offsetX < 0)) {
        this.dropActive = false
      }
    }
```
When dropping of file is canceled by pressing of ESC key, `e.offsetX` equals `0`. Also `e.screenY === 0` is duplicated in expression. I have created the PR with fix.