### PR TITLE
Add typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,55 @@
+import Vue from 'vue'
+  
+// Instance / File
+global {
+  namespace VueUpload {
+    interface File {
+      readonly fileObject: boolean
+      id: string | number
+      size: number
+      name: string
+      type: string
+      active: boolean
+      error: string
+      success: boolean
+      putAction: string
+      postAction: string
+      headers: object
+      data: object
+      timeout: number
+      response: object | string
+      progress: string
+      speed: number
+      xhr: XMLHttpRequest
+      iframe: Element
+    }
+  }
+}
+
+interface VueUploadComponent extends Vue, Element {
+  // Instance / Methods
+  get(id: VueUpload.File | object | string): VueUpload.File | object | boolean
+  add(files: Array<VueUpload.File | File | object> | VueUpload.File | File | object): object | Array<VueUpload.File | object> | boolean
+  addInputFile(el: HTMLInputElement): Array<VueUpload.File>
+  addDataTransfer(dataTransfer: DataTransfer): Promise<Array<VueUpload.File>>
+  update(id: VueUpload.File | object | string, data: object): object | boolean
+  // remove(id: VueUpload.File | object | string): object | boolean // Types are incompatible with Element
+  replace(id1: VueUpload.File | object | string, id2: VueUpload.File | object | string): boolean
+  clear(): boolean
+
+  // Instance / Data
+  readonly files: Array<VueUpload.File>
+  readonly features: { html5?: boolean; directory?: boolean; drag?: boolean }
+  active: boolean
+  readonly dropActive: true
+  readonly uploaded: true
+}
+
+// module 'vue/types/vue' {
+  // https://stackoverflow.com/a/41286276/5221998
+  // interface Vue {
+  //   readonly $refs: { [key: string]: VueUploadComponent };
+  // }
+// }
+
+export default VueUploadComponent

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,14 +26,14 @@ global {
   }
 }
 
-interface VueUploadComponent extends Vue, Element {
+class _ extends Vue {
   // Instance / Methods
   get(id: VueUpload.File | object | string): VueUpload.File | object | boolean
   add(files: Array<VueUpload.File | File | object> | VueUpload.File | File | object): object | Array<VueUpload.File | object> | boolean
   addInputFile(el: HTMLInputElement): Array<VueUpload.File>
   addDataTransfer(dataTransfer: DataTransfer): Promise<Array<VueUpload.File>>
   update(id: VueUpload.File | object | string, data: object): object | boolean
-  // remove(id: VueUpload.File | object | string): object | boolean // Types are incompatible with Element
+  remove(id: VueUpload.File | object | string): object | boolean
   replace(id1: VueUpload.File | object | string, id2: VueUpload.File | object | string): boolean
   clear(): boolean
 
@@ -52,4 +52,4 @@ interface VueUploadComponent extends Vue, Element {
   // }
 // }
 
-export default VueUploadComponent
+export default _

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "module": "dist/vue-upload-component.js",
   "unpkg": "dist/vue-upload-component.js",
   "jsdelivr": "dist/vue-upload-component.js",
+  "typings": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lian-yue/vue-upload-component.git"


### PR DESCRIPTION
Usage

```ts
import { Component, Vue } from 'vue-property-decorator'
import VUpload from 'vue-upload-component'

type VFile = VueUpload.File

@Component({
  components: {
    VUpload
  }
})
export default class FileUpload extends Vue {
  inputFile(newFile: VFile, oldFile: VFile) {
    // Automatic upload
    if (
      Boolean(newFile) !== Boolean(oldFile) ||
      oldFile.error !== newFile.error
    ) {
      // @ts-ignore
      if (!this.$refs.upload.active) this.$refs.upload.active = true
    }
  }
}
```

> Due to Typescript rules, notice that I can't support the usage of accessing `vm.$data` and `vm.$methods` in `this.$refs`

---
### Edit
`this.$refs` can be use by doing type casting

```ts
      const vueUpload = this.$refs.upload as VUpload
      if (!vueUpload.active) vueUpload.active = true
```