### PR TITLE
Fixes #173

### DIFF
--- a/src/FileUpload.vue
+++ b/src/FileUpload.vue
@@ -1290,7 +1290,7 @@ export default {
 
     onDragleave(e) {
       e.preventDefault()
-      if (e.target.nodeName === 'HTML' || (e.screenX === 0 && e.screenY === 0 && !e.fromElement && e.offsetX <= 0)) {
+      if (e.target.nodeName === 'HTML' || e.target === e.explicitOriginalTarget || (e.screenX === 0 && e.screenY === 0 && !e.fromElement && e.offsetX <= 0)) {
         this.dropActive = false
       }
     },


### PR DESCRIPTION
This should fix the issue in #173 

I wasn't able to notice any unintended consequences from adding this additional check to remove the `dropActive` - it all seemed to work as expected. Open to feedback!

Thanks.

## Before
![vue-upload-component-before](https://user-images.githubusercontent.com/6248612/40552094-5f2d5322-6004-11e8-9723-60b651d10c01.gif)

## After
![vue-upload-component-after](https://user-images.githubusercontent.com/6248612/40552100-6286c440-6004-11e8-99a5-575e5887bc22.gif)
