### PR TITLE
Edit typo in Documentation

### DIFF
--- a/docs/docs/en.md
+++ b/docs/docs/en.md
@@ -586,7 +586,7 @@ File List
 
 * **Usage:**
   ```html
-  <file-upload :value="files" @input="updatetValue"></file-upload>
+  <file-upload :value="files" @input="updatedValue"></file-upload>
   <!--or-->
   <file-upload v-model="files"></file-upload>
   ```
@@ -856,7 +856,7 @@ Default for `v-model` binding
 * **Usage:**
   ```html
   <template>
-    <file-upload :value="files" @input="updatetValue"></file-upload>
+    <file-upload :value="files" @input="updatedValue"></file-upload>
     <!--or-->
     <file-upload v-model="files"></file-upload>
   </template>
@@ -868,7 +868,7 @@ Default for `v-model` binding
       }
     },
     methods: {
-      updatetValue(value) {
+      updatedValue(value) {
         this.files = value
       }
     }

--- a/docs/docs/zh-cn.md
+++ b/docs/docs/zh-cn.md
@@ -373,7 +373,7 @@ input标签的 `name` 属性
 
 * **示例:**
   ```html
-  <file-upload :value="files" @input="updatetValue"></file-upload>
+  <file-upload :value="files" @input="updatedValue"></file-upload>
   <!--或-->
   <file-upload v-model="files"></file-upload>
   ```
@@ -610,7 +610,7 @@ input标签的 `name` 属性
 * **示例:**
   ```html
   <template>
-    <file-upload :value="files" @input="updatetValue"></file-upload>
+    <file-upload :value="files" @input="updatedValue"></file-upload>
     <!--或者-->
     <file-upload v-model="files"></file-upload>
   </template>
@@ -622,7 +622,7 @@ input标签的 `name` 属性
       }
     },
     methods: {
-      updatetValue(value) {
+      updatedValue(value) {
         this.files = value
       }
     }


### PR DESCRIPTION
In documentation, I saw `@input="updatetValue"`. 
I think this one probably maybe a typo; 
`updatetValue` --> `updatedValue`