### PR TITLE
Fix typo in method name

### DIFF
--- a/docs/views/examples/Full.vue
+++ b/docs/views/examples/Full.vue
@@ -107,7 +107,7 @@
         </file-upload>
         <div class="dropdown-menu">
           <label class="dropdown-item" :for="name">Add files</label>
-          <a class="dropdown-item" href="#" @click="onAddFolader">Add folder</a>
+          <a class="dropdown-item" href="#" @click="onAddFolder">Add folder</a>
           <a class="dropdown-item" href="#" @click.prevent="addData.show = true">Add data</a>
         </div>
       </div>
@@ -604,8 +604,8 @@ export default {
       this.editFile.show = false
     },
 
-    // add folader
-    onAddFolader() {
+    // add folder
+    onAddFolder() {
       if (!this.$refs.upload.features.directory) {
         this.alert('Your browser does not support')
         return


### PR DESCRIPTION
A tiny typo in a method name. Thanks for the component! Really useful! :tada: 