### PR TITLE
add missing proptype for 'drop' property

### DIFF
--- a/src/FileUpload.vue
+++ b/src/FileUpload.vue
@@ -123,6 +123,7 @@ export default {
 
 
     drop: {
+      type: Boolean,
       default: false,
     },
 


### PR DESCRIPTION
This PR is to add the type checking for property `drop`. This should help adding the ability of drag and drop with a short declaration instead of a full declaration (same as property `drop-directory`).
Without the type, we have to define `:drop="true"` in order to make it works.

Before adding PropType for property `drop`
![image](https://user-images.githubusercontent.com/15758406/130748228-f252c9b4-742e-4f50-b75d-7d496b11310e.png) ![image](https://user-images.githubusercontent.com/15758406/130749046-c05044d5-6074-4b15-86db-e4ab7a55cd34.png)

After adding PropType for property `drop`
![image](https://user-images.githubusercontent.com/15758406/130748228-f252c9b4-742e-4f50-b75d-7d496b11310e.png) ![image](https://user-images.githubusercontent.com/15758406/130748311-dc17dd45-c7fe-4354-8c2a-05d816dd33c3.png) 
