### PR TITLE
add lastModified to form data

### DIFF
--- a/src/FileUpload.vue
+++ b/src/FileUpload.vue
@@ -1044,6 +1044,7 @@ export default defineComponent({
           form.append(key, value)
         }
       }
+      form.append('lastModified', Math.round(file.file.lastModified / 1000))
 
       // Moved file.name as the first option to set the filename of the uploaded file, since file.name
       // contains the full (relative) path of the file not just the filename as in file.file.filename

--- a/src/chunk/ChunkUploadHandler.js
+++ b/src/chunk/ChunkUploadHandler.js
@@ -348,7 +348,8 @@ export default class ChunkUploadHandler {
       url: this.action,
       body: Object.assign(this.finishBody, {
         phase: 'finish',
-        session_id: this.sessionId
+        session_id: this.sessionId,
+        lastModified: Math.round(this.file.file.lastModified / 1000)
       })
     }).then(res => {
       this.file.response = res


### PR DESCRIPTION
Add lastModified of the uploaded file(s) to the form field.
Server side code can use this field to correctly touch the uploaded file with the correct date / time instead of current date time.